### PR TITLE
Changes done to test walking

### DIFF
--- a/spot_description/urdf/spot.physics.gazebo.xacro
+++ b/spot_description/urdf/spot.physics.gazebo.xacro
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+
+<robot name="spot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+        
+    <xacro:macro name="spot_gazebo_physics" params="leg_kp:=1e+07 leg_kd:=100.0 leg_mu1=1.0 leg_mu2=1.0 leg_fdir1=''">
+
+        <gazebo reference="front_left_lower_leg">
+            <kp>${leg_kp}</kp>
+            <kd>${leg_kd}</kd>
+            <mu1>${leg_mu1}</mu1>
+            <mu2>${leg_mu2}</mu2>
+            <!--<xacro:if value="${'${leg_fdir1}' != ''}">
+                <fdir1>${leg_fdir1}</fdir1>
+            </xacro:if>-->
+            <!--<sensor name="contact" type="contact">
+                <contact>
+                    <collision>${leg_name}_lower_leg_collision</collision>
+                    <collision>${leg_name}_lower_leg_collision_1</collision>
+                </contact>
+            </sensor>-->
+        </gazebo>
+
+        <gazebo reference="front_right_lower_leg">
+          <collision>
+            <surface>
+              <ode>
+              <kp>${leg_kp}</kp>
+              <kd>${leg_kd}</kd>
+              <mu1>${leg_mu1}</mu1>
+              <mu2>${leg_mu2}</mu2>
+              </ode>
+            </surface>
+            </collision>
+            <!--<xacro:if value="${'${leg_fdir1}' != ''}">
+                <fdir1>${leg_fdir1}</fdir1>
+            </xacro:if>-->
+            <!--<sensor name="contact" type="contact">
+                <contact>
+                    <collision>${leg_name}_lower_leg_collision</collision>
+                    <collision>${leg_name}_lower_leg_collision_1</collision>
+                </contact>
+            </sensor>-->
+        </gazebo>
+
+
+        <gazebo reference="rear_left_lower_leg">
+            <kp>${leg_kp}</kp>
+            <kd>${leg_kd}</kd>
+            <mu1>${leg_mu1}</mu1>
+            <mu2>${leg_mu2}</mu2>
+            <!--<xacro:if value="${'${leg_fdir1}' != ''}">
+                <fdir1>${leg_fdir1}</fdir1>
+            </xacro:if>-->
+            <!--<sensor name="contact" type="contact">
+                <contact>
+                    <collision>${leg_name}_lower_leg_collision</collision>
+                    <collision>${leg_name}_lower_leg_collision_1</collision>
+                </contact>
+            </sensor>-->
+        </gazebo>
+
+
+        <gazebo reference="rear_right_lower_leg">
+            <kp>${leg_kp}</kp>
+            <kd>${leg_kd}</kd>
+            <mu1>${leg_mu1}</mu1>
+            <mu2>${leg_mu2}</mu2>
+            <!--<xacro:if value="${'${leg_fdir1}' != ''}">
+                <fdir1>${leg_fdir1}</fdir1>
+            </xacro:if>-->
+            <!--<sensor name="contact" type="contact">
+                <contact>
+                    <collision>${leg_name}_lower_leg_collision</collision>
+                    <collision>${leg_name}_lower_leg_collision_1</collision>
+                </contact>
+            </sensor>-->
+        </gazebo>
+
+
+
+    </xacro:macro>     
+    
+</robot>       

--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -156,12 +156,12 @@
         
         <!-- Gazebo ROS Control plugin -->
         <xacro:if value="${interface_type == 'gazebo'}">
-+          <gazebo>
-+            <plugin name="gz_ros2_control::GazeboSimROS2ControlPlugin" filename="gz_ros2_control-system">
-+              <parameters>$(find spot_description)/config/ros2_control_spot.yaml</parameters>
-+          </plugin>
-+          </gazebo>
-+        </xacro:if>
+          <gazebo>
+            <plugin name="gz_ros2_control::GazeboSimROS2ControlPlugin" filename="gz_ros2_control-system">
+              <parameters>$(find spot_description)/config/ros2_control_spot.yaml</parameters>
+          </plugin>
+          </gazebo>
+        </xacro:if>
         
     </xacro:macro>
 

--- a/spot_description/urdf/spot.sensors.gazebo.xacro
+++ b/spot_description/urdf/spot.sensors.gazebo.xacro
@@ -119,6 +119,32 @@
       <xacro:spot_camera prefix="${prefix}" name="back" simulate="1" />
       <xacro:fixed_joint name="camera_back_j" parent="${prefix}base_link" child="${prefix}camera_back" xyz="-0.425 0 0.01" rpy="0 0.3 ${-pi}" />
     
+    </xacro:macro>
+    
+    <!-- Odometry simulation -->
+    <xacro:macro name="spot_odometry_publisher">
+      <gazebo>
+        <plugin filename="gz-sim-odometry-publisher-system" name="gz::sim::systems::OdometryPublisher">
+          <odom_frame>odom</odom_frame>
+          <robot_base_frame>base_link</robot_base_frame>
+          <odom_publish_frequency>10</odom_publish_frequency>
+          <tf_topic>spot/odom</tf_topic>
+        </plugin>
+      </gazebo> 
     </xacro:macro>    
+    
+    <!-- PosePublisher - P3D-equivalent -->
+    <xacro:macro name="spot_pose_publisher">
+      <gazebo>
+        <plugin filename="gz-sim-pose-publisher-system" name="gz::sim::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_nested_model_pose>true</publish_nested_model_pose>
+          <publish_model_pose>true</publish_model_pose>
+          <update_frequency>30</update_frequency>
+          <use_pose_vector_msg>false</use_pose_vector_msg>
+        </plugin>
+      </gazebo> 
+    </xacro:macro>  
+
     
 </robot>

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -5,7 +5,8 @@
   <xacro:include filename="$(find spot_description)/urdf/spot_macro.xacro" />
   <!-- Macros for loading the ROS 2 control tags -->
   <xacro:include filename="$(find spot_description)/urdf/spot.ros2_control.xacro" />
-
+  <xacro:include filename="$(find spot_description)/urdf/spot.physics.gazebo.xacro" />
+  
   <!-- General parameters -->
 
   <!-- String that will be prepended to all joints and links-->
@@ -65,5 +66,7 @@
     <xacro:add_cameras prefix="$(arg tf_prefix)" />
   </xacro:if>
 
+  <!-- Gazebo tags -->
+  <xacro:spot_gazebo_physics />
 
 </robot>

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -69,4 +69,11 @@
   <!-- Gazebo tags -->
   <xacro:spot_gazebo_physics />
 
+  <!-- Gazebo plugins: odom state publisher -->
+  <!--<xacro:spot_odometry_publisher />-->
+
+  <!-- Gazebo plugins: pose publisher -->
+  <xacro:spot_pose_publisher />
+
+
 </robot>

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -67,7 +67,7 @@
   </xacro:if>
 
   <!-- Gazebo tags -->
-  <xacro:spot_gazebo_physics />
+  <!--<xacro:spot_gazebo_physics />-->
 
   <!-- Gazebo plugins: odom state publisher -->
   <!--<xacro:spot_odometry_publisher />-->

--- a/spot_description/urdf/spot_macro.xacro
+++ b/spot_description/urdf/spot_macro.xacro
@@ -6,8 +6,11 @@
     feet:=false
     gripperless:=false
     custom_gripper_base_link:=''
-			tf_prefix
-			include_transmissions=false">
+    tf_prefix
+    include_transmissions=false
+    leg_damping:='0.0'
+    leg_friction:='0.0'"> 
+    <!-- 1.0, 0.2. First time it walked we used damping:=1.0 and friction:=0.2. Setting it back to zeros it was still walking -->
 
         <link name="${tf_prefix}body">
             <visual>
@@ -85,7 +88,8 @@
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}front_left_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
-                upper="0.78539816339744827899" /> <dynamics damping="1.0" friction="0.2" />
+                upper="0.78539816339744827899" /> 
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_left_hip_x_tran">
@@ -125,7 +129,8 @@
             <parent link="${tf_prefix}front_left_hip" />
             <child link="${tf_prefix}front_left_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
-                upper="2.2951079663725435509" /> <dynamics damping="1.0" friction="0.2" />
+                upper="2.2951079663725435509" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />  
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_left_hip_y_tran">
@@ -172,7 +177,8 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}front_left_upper_leg" />
             <child link="${tf_prefix}front_left_lower_leg" />
-            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.254801" /> <dynamics damping="1.0" friction="0.2" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.254801" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_left_knee_tran">
@@ -206,7 +212,8 @@
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}front_right_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
-                upper="0.78539816339744827899" /> <dynamics damping="1.0" friction="0.2" />
+                upper="0.78539816339744827899" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />    
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_right_hip_x_tran">
@@ -246,7 +253,8 @@
             <parent link="${tf_prefix}front_right_hip" />
             <child link="${tf_prefix}front_right_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
-                upper="2.2951079663725435509" /> <dynamics damping="1.0" friction="0.2" />
+                upper="2.2951079663725435509" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_right_hip_y_tran">
@@ -293,7 +301,8 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}front_right_upper_leg" />
             <child link="${tf_prefix}front_right_lower_leg" />
-            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.247563" /> <dynamics damping="1.0" friction="0.2" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.247563" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_right_knee_tran">
@@ -327,7 +336,8 @@
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}rear_left_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
-                upper="0.78539816339744827899" /> <dynamics damping="1.0" friction="0.2" />
+                upper="0.78539816339744827899" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />    
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_left_hip_x_tran">
@@ -367,7 +377,8 @@
             <parent link="${tf_prefix}rear_left_hip" />
             <child link="${tf_prefix}rear_left_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
-                upper="2.2951079663725435509" /> <dynamics damping="1.0" friction="0.2" />
+                upper="2.2951079663725435509" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />    
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_left_hip_y_tran">
@@ -414,7 +425,8 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}rear_left_upper_leg" />
             <child link="${tf_prefix}rear_left_lower_leg" />
-            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.267153" /> <dynamics damping="1.0" friction="0.2" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.267153" /> 
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_left_knee_tran">
@@ -448,7 +460,8 @@
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}rear_right_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
-                upper="0.78539816339744827899" /> <dynamics damping="1.0" friction="0.2" />
+                upper="0.78539816339744827899" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_right_hip_x_tran">
@@ -488,7 +501,8 @@
             <parent link="${tf_prefix}rear_right_hip" />
             <child link="${tf_prefix}rear_right_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
-                upper="2.2951079663725435509" /> <dynamics damping="1.0" friction="0.2" />
+                upper="2.2951079663725435509" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />    
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_right_hip_y_tran">
@@ -535,7 +549,8 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}rear_right_upper_leg" />
             <child link="${tf_prefix}rear_right_lower_leg" />
-            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.257725" /> <dynamics damping="1.0" friction="0.2" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.257725" />
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_right_knee_tran">

--- a/spot_description/urdf/spot_macro.xacro
+++ b/spot_description/urdf/spot_macro.xacro
@@ -85,7 +85,7 @@
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}front_left_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
-                upper="0.78539816339744827899" />
+                upper="0.78539816339744827899" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_left_hip_x_tran">
@@ -125,7 +125,7 @@
             <parent link="${tf_prefix}front_left_hip" />
             <child link="${tf_prefix}front_left_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
-                upper="2.2951079663725435509" />
+                upper="2.2951079663725435509" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_left_hip_y_tran">
@@ -172,7 +172,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}front_left_upper_leg" />
             <child link="${tf_prefix}front_left_lower_leg" />
-            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.254801" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.254801" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_left_knee_tran">
@@ -206,7 +206,7 @@
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}front_right_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
-                upper="0.78539816339744827899" />
+                upper="0.78539816339744827899" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_right_hip_x_tran">
@@ -246,7 +246,7 @@
             <parent link="${tf_prefix}front_right_hip" />
             <child link="${tf_prefix}front_right_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
-                upper="2.2951079663725435509" />
+                upper="2.2951079663725435509" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_right_hip_y_tran">
@@ -293,7 +293,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}front_right_upper_leg" />
             <child link="${tf_prefix}front_right_lower_leg" />
-            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.247563" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.247563" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_right_knee_tran">
@@ -327,7 +327,7 @@
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}rear_left_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
-                upper="0.78539816339744827899" />
+                upper="0.78539816339744827899" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_left_hip_x_tran">
@@ -367,7 +367,7 @@
             <parent link="${tf_prefix}rear_left_hip" />
             <child link="${tf_prefix}rear_left_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
-                upper="2.2951079663725435509" />
+                upper="2.2951079663725435509" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_left_hip_y_tran">
@@ -414,7 +414,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}rear_left_upper_leg" />
             <child link="${tf_prefix}rear_left_lower_leg" />
-            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.267153" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.267153" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_left_knee_tran">
@@ -448,7 +448,7 @@
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}rear_right_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
-                upper="0.78539816339744827899" />
+                upper="0.78539816339744827899" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_right_hip_x_tran">
@@ -488,7 +488,7 @@
             <parent link="${tf_prefix}rear_right_hip" />
             <child link="${tf_prefix}rear_right_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
-                upper="2.2951079663725435509" />
+                upper="2.2951079663725435509" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_right_hip_y_tran">
@@ -535,7 +535,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}rear_right_upper_leg" />
             <child link="${tf_prefix}rear_right_lower_leg" />
-            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.257725" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.257725" /> <dynamics damping="1.0" friction="0.2" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_right_knee_tran">


### PR DESCRIPTION
Up to jazzy (formerly feature/gazebo_sim) we were able to visualize the robot and load it in Gazebo, I think. This branch/PR was created to update the robot parameters/launch/config files such that the robot could walk, move its arms and add cameras to it.

Other than adding cameras, which is by default ON, there were 2 relevant additions regarding physics:

1. Added dynamics parameters (damping/ friction) for the robot legs. Tested with 1.0 and 0.2, robot walked. Set them back to default 0.0 and 0.0 as we noticed that the robot still was able to walk if we zero-ed these values. I suspect then, that adding these parameters is unnecessary, HOWEVER I am leaving the parameters there in case we need to use them in the future (e.g. maybe they are not needed now but will be when testing in a rougher environment?)
2. Added contact parameters (mu1, mu2) to the links that are in contact with the floor (lower legs). Right now, they are commented out in the spot.urdf.xacro (the macro gazebo.physics.xacro) because again, we noted that the robot walked with or without these parameters being used. Leaving the macro there in case it is needed in the future.
