### PR TITLE
Add camera to gripper

### DIFF
--- a/spot_description/urdf/spot.sensors.gazebo.xacro
+++ b/spot_description/urdf/spot.sensors.gazebo.xacro
@@ -118,9 +118,35 @@
 
       <xacro:spot_camera prefix="${prefix}" name="back" simulate="1" />
       <xacro:fixed_joint name="camera_back_j" parent="${prefix}base_link" child="${prefix}camera_back" xyz="-0.425 0 0.01" rpy="0 0.3 ${-pi}" />
-    
+
     </xacro:macro>
-    
+
+    <!-- Gazebo sensor for gripper camera. The arm_camera_link / arm_camera_optical_frame
+         links are in spot_arm_macro.urdf and exist as TF frames on the real robot too. -->
+    <xacro:macro name="add_arm_camera" params="prefix:='' visualize:=0">
+      <gazebo reference="${prefix}arm_camera_link">
+        <sensor name="arm_camera" type="camera">
+          <pose>0 0 0 0 0 0</pose>
+          <update_rate>30</update_rate>
+          <topic>arm_camera/image</topic>
+          <visualize>${visualize}</visualize>
+          <camera>
+            <horizontal_fov>${radians(90)}</horizontal_fov>
+            <image>
+              <width>640</width>
+              <height>480</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.05</near>
+              <far>10.0</far>
+            </clip>
+            <optical_frame_id>${prefix}arm_camera_optical_frame</optical_frame_id>
+          </camera>
+        </sensor>
+      </gazebo>
+    </xacro:macro>
+
     <!-- Odometry simulation -->
     <xacro:macro name="spot_odometry_publisher">
       <gazebo>
@@ -130,9 +156,9 @@
           <odom_publish_frequency>10</odom_publish_frequency>
           <tf_topic>spot/odom</tf_topic>
         </plugin>
-      </gazebo> 
-    </xacro:macro>    
-    
+      </gazebo>
+    </xacro:macro>
+
     <!-- PosePublisher - P3D-equivalent -->
     <xacro:macro name="spot_pose_publisher">
       <gazebo>
@@ -143,8 +169,8 @@
           <update_frequency>30</update_frequency>
           <use_pose_vector_msg>false</use_pose_vector_msg>
         </plugin>
-      </gazebo> 
-    </xacro:macro>  
+      </gazebo>
+    </xacro:macro>
 
-    
+
 </robot>

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -6,7 +6,7 @@
   <!-- Macros for loading the ROS 2 control tags -->
   <xacro:include filename="$(find spot_description)/urdf/spot.ros2_control.xacro" />
   <xacro:include filename="$(find spot_description)/urdf/spot.physics.gazebo.xacro" />
-  
+
   <!-- General parameters -->
 
   <!-- String that will be prepended to all joints and links-->
@@ -40,14 +40,15 @@
   <!-- Load Spot -->
   <xacro:load_spot
     arm="$(arg arm)"
+    custom_gripper_base_link="palm_link"
     feet="$(arg feet)"
-    tf_prefix="$(arg tf_prefix)" 
+    tf_prefix="$(arg tf_prefix)"
     gripperless="$(arg gripperless)"
 	  include_transmissions="$(arg include_transmissions)" />
 
   <!-- Adding the ROS 2 control tags -->
   <xacro:if value="$(arg add_ros2_control_tag)">
-      <xacro:spot_ros2_control interface_type="$(arg hardware_interface_type)" 
+      <xacro:spot_ros2_control interface_type="$(arg hardware_interface_type)"
                                has_arm="$(arg arm)"
                                leasing="$(arg leasing)"
                                hostname="$(arg hostname)"
@@ -59,11 +60,16 @@
                                k_q_p="$(arg k_q_p)"
                                k_qd_p="$(arg k_qd_p)" />
   </xacro:if>
-  
+
   <!-- Adding cameras -->
   <xacro:if value="$(arg simulate_cameras)">
-    <xacro:include filename="$(find spot_description)/urdf/spot.sensors.gazebo.xacro" />  
+    <xacro:include filename="$(find spot_description)/urdf/spot.sensors.gazebo.xacro" />
     <xacro:add_cameras prefix="$(arg tf_prefix)" />
+    <xacro:if value="$(arg arm)">
+      <xacro:unless value="$(arg gripperless)">
+        <xacro:add_arm_camera prefix="$(arg tf_prefix)" />
+      </xacro:unless>
+    </xacro:if>
   </xacro:if>
 
   <!-- Gazebo tags -->

--- a/spot_description/urdf/spot_arm_macro.urdf
+++ b/spot_description/urdf/spot_arm_macro.urdf
@@ -405,6 +405,22 @@
 					</actuator>
 				</transmission>
 			</xacro:if>
+
+      <!-- Gripper camera- Parented to arm_link_wr1f instead of arm_link_fngr.
+           Parenting to the finger made the camera move every with open/close. -->
+      <link name="${tf_prefix}arm_camera_link" />
+      <joint name="${tf_prefix}arm_camera_link_fixed_joint" type="fixed">
+        <origin xyz="0.14995 0 0.035" rpy="0 0 0" />
+        <parent link="${tf_prefix}arm_link_wr1" />
+        <child link="${tf_prefix}arm_camera_link" />
+      </joint>
+
+      <link name="${tf_prefix}arm_camera_optical_frame" />
+      <joint name="${tf_prefix}arm_camera_optical_frame_fixed_joint" type="fixed">
+        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+        <parent link="${tf_prefix}arm_camera_link" />
+        <child link="${tf_prefix}arm_camera_optical_frame" />
+      </joint>
     </xacro:unless>
   </xacro:macro>
 </robot>

--- a/spot_description/urdf/spot_macro.xacro
+++ b/spot_description/urdf/spot_macro.xacro
@@ -5,11 +5,11 @@
     arm:=false
     feet:=false
     gripperless:=false
-    custom_gripper_base_link:=''
+    custom_gripper_base_link:='palm_link'
     tf_prefix
     include_transmissions=false
     leg_damping:='0.0'
-    leg_friction:='0.0'"> 
+    leg_friction:='0.0'">
     <!-- 1.0, 0.2. First time it walked we used damping:=1.0 and friction:=0.2. Setting it back to zeros it was still walking -->
 
         <link name="${tf_prefix}body">
@@ -88,7 +88,7 @@
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}front_left_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
-                upper="0.78539816339744827899" /> 
+                upper="0.78539816339744827899" />
             <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
@@ -130,7 +130,7 @@
             <child link="${tf_prefix}front_left_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
                 upper="2.2951079663725435509" />
-            <dynamics damping="${leg_damping}" friction="${leg_friction}" />  
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_left_hip_y_tran">
@@ -213,7 +213,7 @@
             <child link="${tf_prefix}front_right_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
                 upper="0.78539816339744827899" />
-            <dynamics damping="${leg_damping}" friction="${leg_friction}" />    
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}front_right_hip_x_tran">
@@ -337,7 +337,7 @@
             <child link="${tf_prefix}rear_left_hip" />
             <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
                 upper="0.78539816339744827899" />
-            <dynamics damping="${leg_damping}" friction="${leg_friction}" />    
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_left_hip_x_tran">
@@ -378,7 +378,7 @@
             <child link="${tf_prefix}rear_left_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
                 upper="2.2951079663725435509" />
-            <dynamics damping="${leg_damping}" friction="${leg_friction}" />    
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_left_hip_y_tran">
@@ -425,7 +425,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}rear_left_upper_leg" />
             <child link="${tf_prefix}rear_left_lower_leg" />
-            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.267153" /> 
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.267153" />
             <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
@@ -502,7 +502,7 @@
             <child link="${tf_prefix}rear_right_upper_leg" />
             <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
                 upper="2.2951079663725435509" />
-            <dynamics damping="${leg_damping}" friction="${leg_friction}" />    
+            <dynamics damping="${leg_damping}" friction="${leg_friction}" />
         </joint>
         <xacro:if value="${include_transmissions}">
 					<transmission name="${tf_prefix}rear_right_hip_y_tran">


### PR DESCRIPTION
This adds a camera sensor to the URDF, and adds gazebo tags. Also used for spot in Isaac Sim. See picture for gazebo example:
<img width="3708" height="2336" alt="Screenshot from 2026-08-12 09-45-42" src="https://github.com/user-attachments/assets/5bebb2ea-ac5a-4994-8ccc-b8997e533113" />
